### PR TITLE
protoc_plugin: use protoc like import statements

### DIFF
--- a/src/purerpc/protoc_plugin/plugin.py
+++ b/src/purerpc/protoc_plugin/plugin.py
@@ -8,11 +8,9 @@ from purerpc import Cardinality
 
 
 def generate_import_statement(proto_name):
-    parts = proto_name.replace("-", "_").split("/")
-    package_name = ".".join(parts[:-1])
-    module_name = parts[-1][:-len(".proto")] + "_pb2"
+    module_path = proto_name[:-len(".proto")].replace("-", "_").replace("/", ".") + "_pb2"
     alias = get_python_module_alias(proto_name)
-    return "from " + package_name + " import " + module_name + " as " + alias
+    return "import " + module_path + " as " + alias
 
 
 def get_python_module_alias(proto_name):


### PR DESCRIPTION
instead of generating import statements like:

```
import google.protobuf.empty_pb2
```

generate

```
from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
```

like default protobuf python compiler.

It's convenient for modifing protobuf import path using [protobuf-gen](https://github.com/andreycizov/python-protobuf-gen) like tools.